### PR TITLE
feat: manifest CSP

### DIFF
--- a/background.js
+++ b/background.js
@@ -12,6 +12,8 @@ chrome.webRequest.onHeadersReceived.addListener(({ responseHeaders, url }) => {
     for (let p of cspAllowAll) {
       csp.value = csp.value.replace(`${p}`, `${p} * blob: data:`); // * does not include data: URIs
     }
+    // Discord doesn't even specify a manifest CSP so we create our own
+    csp.value += ' manifest-src * blob: data:;';
 
     // Fix Discord's broken CSP which disallows unsafe-inline due to having a nonce (which they don't even use?)
     csp.value = csp.value.replace(/'nonce-.*?' /, '');


### PR DESCRIPTION
This PR adds a `manifest-src` CSP to allow the user to create `webmanifest`s using blob: or data: URIs. This is mainly to allow plugins to make Discord Web installable as a PWA.